### PR TITLE
Implement checkbox status and custom edit form for homologacion

### DIFF
--- a/src/components/defaultTable/DefaultTable.js
+++ b/src/components/defaultTable/DefaultTable.js
@@ -14,7 +14,7 @@ import IconButton from "../iconButton/IconButton";
 import { Table } from "../table/Table";
 import {useTranslation} from "react-i18next";
 
-export default function DefaultTable({columnHeader, entity, isFilterable = true, isPageable = true, showAddButton = true, detailLink, showDetailsButton, showEditButton, showDeleteButton, predefinedValues, controlled = true, hasRerendered, overrideRows, AddActionButton}){
+export default function DefaultTable({columnHeader, entity, isFilterable = true, isPageable = true, showAddButton = true, detailLink, showDetailsButton, showEditButton, showDeleteButton, predefinedValues, controlled = true, hasRerendered, overrideRows, AddActionButton, EditActionComponent}){
   const { t } = useTranslation();
   const { filter, addItem, deleteItem, updateItem, handleFilter, rows, defaultPagination, handlePagination, rowsNumber, resetFilter, error, resetError, loading } = useTableActions(entity, predefinedValues, controlled, overrideRows, hasRerendered);
   const [action, setAction] = useState('');
@@ -128,13 +128,20 @@ export default function DefaultTable({columnHeader, entity, isFilterable = true,
         )}
         {showEditButton &&
           <div onClick={() => setAction('Edit')}>
-            <EditButton
-              headers={columnHeader.filter(h => h.editable)}
-              entity={entityName}
-              selectedItem={selectedItem}
-              itemPrimaryKey={columnHeader[1].id || ''}
-              initialValues={data}
-              onSubmit={updateItem}/>
+            {EditActionComponent ? (
+              <EditActionComponent
+                selectedItem={selectedItem}
+                onSubmit={updateItem}
+              />
+              ) : (
+              <EditButton
+                headers={columnHeader.filter(h => h.editable)}
+                entity={entityName}
+                selectedItem={selectedItem}
+                itemPrimaryKey={columnHeader[1].id || ''}
+                initialValues={data}
+                onSubmit={updateItem}/>
+            )}
           </div>}
         {showDeleteButton &&
           <div onClick={() => setAction('Delete')}>
@@ -181,5 +188,6 @@ DefaultTable.propTypes = {
   showAddButton: PropTypes.bool,
   hasRerendered: PropTypes.func,
   AddActionButton: PropTypes.node,
+  EditActionComponent: PropTypes.elementType,
   overrideRows: PropTypes.array,
 };

--- a/src/config/equipment/HomologacionSapFields.js
+++ b/src/config/equipment/HomologacionSapFields.js
@@ -1,8 +1,8 @@
 export const HomologacionSapFields = [
   {id: 'id', label: 'ID', hidden: true},
-  {id: 'accessType', label: 'TIPO DE RECURSO', addable: true, editable: false},
-  {id: 'equipmentModelName', label: 'NOMBRE DE MODELO DE RECURSO', addable: true, editable: false},
-  {id: 'equipmentModelId', label: 'ID DE MODELO DE RECURSO', addable: true, editable: false},
+  {id: 'accessType', label: 'TIPO DE RECURSO', addable: true, editable: true},
+  {id: 'equipmentModelName', label: 'NOMBRE DE MODELO DE RECURSO', addable: true, editable: true},
+  {id: 'equipmentModelId', label: 'ID DE MODELO DE RECURSO', addable: true, editable: true},
   {id: 'idMaterialSap', label: 'MATERIAL SAP', addable: true, editable: true},
   {id: 'nameSap', label: 'NOMBRE DE MATERIAL SAP', addable: true, editable: true},
   {id: 'status', label: 'ESTADO', addable: true, editable: true},

--- a/src/containers/equipments/EquipmentAdminManager/EditHomologacionSapForm.js
+++ b/src/containers/equipments/EquipmentAdminManager/EditHomologacionSapForm.js
@@ -4,15 +4,14 @@ import {Dialog, DialogTitle, DialogContent, DialogActions, Switch, FormControlLa
 import CustomSelect from '../../../components/customSelect/CustomSelect';
 import TypeField from '../../../components/typeField/TypeField';
 import IconLabelButton from '../../../components/iconLabelButton/IconLabelButton';
-import ContainedButton from '../../../components/containedButton/ContainedButton';
 import axios from 'axios';
 import {Backend} from '../../../data';
 import Auth from '../../../services/Auth';
 import {HomologacionSapFields} from '../../../config/equipment/HomologacionSapFields';
-import {Add, Cancel} from '@material-ui/icons';
+import {Edit, Cancel} from '@material-ui/icons';
 import {useTranslation} from 'react-i18next';
 
-export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}) {
+export default function EditHomologacionSapForm({selectedItem, onSubmit}) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [formValues, setFormValues] = useState({});
@@ -29,20 +28,25 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
   }, []);
 
   useEffect(() => {
-    if(formValues.accessType){
-      axios.get(`${Backend.equipments.equipmentModelsNames.url}?category=ANCILLARY&accessType=${formValues.accessType}`, Auth.authorize())
+    const access = formValues.accessType || selectedItem.accessType;
+    if(access){
+      axios.get(`${Backend.equipments.equipmentModelsNames.url}?category=ANCILLARY&accessType=${access}`, Auth.authorize())
         .then(res => {
           const opts = res.data.map(v => ({id: v.id, key: v.name, value: v.name}));
           setModelOptions(opts);
         });
     }
-  }, [formValues.accessType]);
+  }, [formValues.accessType, selectedItem.accessType]);
 
-  const handleInputChange = (event) => {
-    const { id, value } = event.target;
+  useEffect(() => {
+    setStatusChecked(selectedItem.status !== 'Deshabilitado');
+  }, [selectedItem]);
+
+  const handleInputChange = event => {
+    const {id, value} = event.target;
     if (id === 'equipmentModelId') {
       const option = modelOptions.find(o => o.value === value);
-      setFormValues(prev => ({...prev, [id]: option ? option.id : value}));
+      setFormValues(prev => ({...prev, [id]: option ? option.id : value, equipmentModelName: value}));
     } else {
       setFormValues(prev => ({...prev, [id]: value}));
     }
@@ -52,9 +56,9 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
   const handleClose = () => { setOpen(false); setFormValues({}); };
 
   const handleSubmit = () => {
-    const { accessType, ...dataToSubmit } = { ...predefinedValues, ...formValues };
     const status = statusChecked ? 'Habilitado' : 'Deshabilitado';
-    onSubmit({...dataToSubmit, status});
+    const dataToSubmit = {...selectedItem, ...formValues, status};
+    onSubmit(selectedItem, dataToSubmit);
     handleClose();
   };
 
@@ -64,16 +68,16 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
 
   return (
     <div>
-      <div onClick={handleClickOpen}>
-        <ContainedButton />
+      <div onClick={handleClickOpen} className="edit-button-container">
+        <Edit />
       </div>
       <Dialog className="form-dialog-container" open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
-        <DialogTitle className="form-dialog-title" id="form-dialog-title">{t('add')}</DialogTitle>
+        <DialogTitle className="form-dialog-title" id="form-dialog-title">{t('edit')}</DialogTitle>
         <DialogContent>
-          <CustomSelect field={accessField} onChange={handleInputChange} />
-          <CustomSelect field={modelField} onChange={handleInputChange} />
+          <CustomSelect field={accessField} onChange={handleInputChange} defaultValue={selectedItem.accessType} />
+          <CustomSelect field={modelField} onChange={handleInputChange} defaultValue={selectedItem.equipmentModelName} />
           {inputFields.map(field => (
-            <TypeField key={field.id} defaultValue="" field={field} onChange={handleInputChange} />
+            <TypeField key={field.id} defaultValue={selectedItem[field.id]} field={field} onChange={handleInputChange} />
           ))}
           <FormControlLabel
             control={<Switch color="secondary" checked={statusChecked} onChange={() => setStatusChecked(!statusChecked)} />}
@@ -82,14 +86,14 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
         </DialogContent>
         <DialogActions>
           <IconLabelButton icon={<Cancel />} label={t('tpl.enhancedTable.cancel')} onClick={handleClose} />
-          <IconLabelButton icon={<Add />} label={t('add')} onClick={handleSubmit} />
+          <IconLabelButton icon={<Edit />} label={t('edit')} onClick={handleSubmit} />
         </DialogActions>
       </Dialog>
     </div>
   );
 }
 
-AddHomologacionSapForm.propTypes = {
-  predefinedValues: PropTypes.object,
+EditHomologacionSapForm.propTypes = {
+  selectedItem: PropTypes.object.isRequired,
   onSubmit: PropTypes.func
 };

--- a/src/containers/equipments/EquipmentAdminManager/HomologacionSapPage.js
+++ b/src/containers/equipments/EquipmentAdminManager/HomologacionSapPage.js
@@ -3,6 +3,7 @@ import DefaultTable from '../../../components/defaultTable/DefaultTable';
 import {EquipmentAdminCategories} from '../../../config/equipment/EquipmentImportableProperties';
 import {HomologacionSapFields} from '../../../config/equipment/HomologacionSapFields';
 import AddHomologacionSapForm from './AddHomologacionSapForm';
+import EditHomologacionSapForm from './EditHomologacionSapForm';
 import {useFetchAccessTypes} from '../../../hooks/useFetchAccessTypes';
 
 
@@ -16,6 +17,7 @@ export default function HomologacionSapPage(){
       showEditButton
       showDeleteButton={false}
       AddActionButton={AddHomologacionSapForm}
+      EditActionComponent={EditHomologacionSapForm}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add status toggle checkbox when creating homologación
- allow editing all homologación fields through a new dialog
- enable edition fields in homologación configuration
- support custom edit components in DefaultTable
- wire new edit dialog into HomologacionSapPage
- fix reference to custom edit component

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a51189fb8832388f787589387c79e