### PR TITLE
Fix homologacion edit fetching

### DIFF
--- a/src/config/equipment/HomologacionSapFields.js
+++ b/src/config/equipment/HomologacionSapFields.js
@@ -1,7 +1,7 @@
 export const HomologacionSapFields = [
   {id: 'id', label: 'ID', hidden: true},
-  {id: 'accessType', label: 'TIPO DE RECURSO', addable: true, editable: true},
-  {id: 'equipmentModelName', label: 'NOMBRE DE MODELO DE RECURSO', addable: true, editable: true},
+  {id: 'accessType', label: 'TIPO DE RECURSO', type: 'enum', values: [], addable: true, editable: true},
+  {id: 'equipmentModelName', label: 'NOMBRE DE MODELO DE RECURSO', type: 'enum', values: [], addable: true, editable: true},
   {id: 'equipmentModelId', label: 'ID DE MODELO DE RECURSO', addable: true, editable: true},
   {id: 'idMaterialSap', label: 'MATERIAL SAP', addable: true, editable: true},
   {id: 'nameSap', label: 'NOMBRE DE MATERIAL SAP', addable: true, editable: true},

--- a/src/containers/equipments/EquipmentAdminManager/AddHomologacionSapForm.js
+++ b/src/containers/equipments/EquipmentAdminManager/AddHomologacionSapForm.js
@@ -40,9 +40,9 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
 
   const handleInputChange = (event) => {
     const { id, value } = event.target;
-    if (id === 'equipmentModelId') {
+    if (id === 'equipmentModelName') {
       const option = modelOptions.find(o => o.value === value);
-      setFormValues(prev => ({...prev, [id]: option ? option.id : value}));
+      setFormValues(prev => ({...prev, equipmentModelId: option ? option.id : value, equipmentModelName: value}));
     } else {
       setFormValues(prev => ({...prev, [id]: value}));
     }
@@ -59,7 +59,7 @@ export default function AddHomologacionSapForm({predefinedValues = {}, onSubmit}
   };
 
   const accessField = {...HomologacionSapFields.find(f => f.id === 'accessType'), values: accessOptions};
-  const modelField = {...HomologacionSapFields.find(f => f.id === 'equipmentModelId'), values: modelOptions};
+  const modelField = {...HomologacionSapFields.find(f => f.id === 'equipmentModelName'), values: modelOptions};
   const inputFields = HomologacionSapFields.filter(f => ['idMaterialSap', 'nameSap'].includes(f.id));
 
   return (

--- a/src/containers/equipments/EquipmentAdminManager/EditHomologacionSapForm.js
+++ b/src/containers/equipments/EquipmentAdminManager/EditHomologacionSapForm.js
@@ -20,23 +20,29 @@ export default function EditHomologacionSapForm({selectedItem, onSubmit}) {
   const [statusChecked, setStatusChecked] = useState(true);
 
   useEffect(() => {
-    axios.get(`${Backend.equipments.equipmentModelsAccessTypes.url}?category=ANCILLARY`, Auth.authorize())
-      .then(res => {
-        const opts = res.data.map(v => ({id: v, key: v, value: v}));
-        setAccessOptions(opts);
-      });
-  }, []);
-
-  useEffect(() => {
-    const access = formValues.accessType || selectedItem.accessType;
-    if(access){
-      axios.get(`${Backend.equipments.equipmentModelsNames.url}?category=ANCILLARY&accessType=${access}`, Auth.authorize())
+    if(open){
+      axios.get(`${Backend.equipments.equipmentModelsAccessTypes.url}?category=ANCILLARY`, Auth.authorize())
         .then(res => {
-          const opts = res.data.map(v => ({id: v.id, key: v.name, value: v.name}));
-          setModelOptions(opts);
+          const opts = res.data.map(v => ({id: v, key: v, value: v}));
+          setAccessOptions(opts);
         });
     }
-  }, [formValues.accessType, selectedItem.accessType]);
+  }, [open]);
+
+  useEffect(() => {
+    if(open){
+      const access = formValues.accessType || selectedItem.accessType;
+      if(access){
+        axios.get(`${Backend.equipments.equipmentModelsNames.url}?category=ANCILLARY&accessType=${access}`, Auth.authorize())
+          .then(res => {
+            const opts = res.data.map(v => ({id: v.id, key: v.name, value: v.name}));
+            setModelOptions(opts);
+          });
+      } else {
+        setModelOptions([]);
+      }
+    }
+  }, [formValues.accessType, selectedItem.accessType, open]);
 
   useEffect(() => {
     setStatusChecked(selectedItem.status !== 'Deshabilitado');
@@ -44,26 +50,31 @@ export default function EditHomologacionSapForm({selectedItem, onSubmit}) {
 
   const handleInputChange = event => {
     const {id, value} = event.target;
-    if (id === 'equipmentModelId') {
+    if (id === 'equipmentModelName') {
       const option = modelOptions.find(o => o.value === value);
-      setFormValues(prev => ({...prev, [id]: option ? option.id : value, equipmentModelName: value}));
+      setFormValues(prev => ({...prev, equipmentModelId: option ? option.id : value, equipmentModelName: value}));
     } else {
       setFormValues(prev => ({...prev, [id]: value}));
     }
   };
 
   const handleClickOpen = () => setOpen(true);
-  const handleClose = () => { setOpen(false); setFormValues({}); };
+  const handleClose = () => {
+    setOpen(false);
+    setFormValues({});
+    setAccessOptions([]);
+    setModelOptions([]);
+  };
 
   const handleSubmit = () => {
     const status = statusChecked ? 'Habilitado' : 'Deshabilitado';
-    const dataToSubmit = {...selectedItem, ...formValues, status};
-    onSubmit(selectedItem, dataToSubmit);
+    const { accessType, equipmentModelName, ...rest } = { ...selectedItem, ...formValues, status };
+    onSubmit(selectedItem, rest);
     handleClose();
   };
 
   const accessField = {...HomologacionSapFields.find(f => f.id === 'accessType'), values: accessOptions};
-  const modelField = {...HomologacionSapFields.find(f => f.id === 'equipmentModelId'), values: modelOptions};
+  const modelField = {...HomologacionSapFields.find(f => f.id === 'equipmentModelName'), values: modelOptions};
   const inputFields = HomologacionSapFields.filter(f => ['idMaterialSap', 'nameSap'].includes(f.id));
 
   return (


### PR DESCRIPTION
## Summary
- load access type options only when the edit dialog opens
- clear old access/model options when closing dialog
- fetch model options when access type changes while dialog is open

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: esw not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a602baf808323a5b8c9df259115a0