### PR TITLE
refactor: downgrade carga certificada to mui v4

### DIFF
--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -43,6 +43,7 @@ const IpAddressesManagerPage = React.lazy( () => import('../containers/resources
 const IpAddressInfoPage = React.lazy( () => import('../containers/resources/IpAddressesManager/IpAddressInfoPage'));
 const ProvisioningProductDetailsPage = React.lazy(() => import('../containers/services/ProvisioningProductDetailsPage'));
 const EsimNotificationInfoPage = React.lazy(() => import('../containers/equipments/SimcardManager/EsimNotificationInfoPage'));
+const CargaCertificadaPage = React.lazy(() => import('../containers/equipments/CargaCertificada/CargaCertificadaPage'));
 export const routePaths = {
   street: '/streets',
   provTagInfo: '/provTagInfo/:tagId/provTagActionInfo/:tagActionId',
@@ -72,6 +73,7 @@ export const routePaths = {
   postalAddresses: '/postaladresses',
   buildings: '/buildings',
   eSimNotification: '/esim/notification/:equipmentId',
+  certifiedLoad: '/certifiedLoad',
   buildingMaps: '/map'
 };
 
@@ -179,6 +181,12 @@ export const ROUTES = {
     exact: true,
     path: routePaths.ancillaryEquipmentsInfo,
     content: <AncillaryEquipmentInfoPage />,
+  },
+  certifiedLoad: {
+    scopes: [resourcesScopes.ancillaryEquipments.read],
+    exact: true,
+    path: routePaths.certifiedLoad,
+    content: <CargaCertificadaPage />,
   },
   equipmentsAdmin: {
     scopes: [resourcesScopes.equipmentsAdmin.read],

--- a/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
+++ b/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Typography, Chip, LinearProgress } from '@material-ui/core';
+import WarehouseSearch from './WarehouseSearch';
+import StandardItemsTable from './StandardItemsTable';
+import { Backend } from '../../../data';
+import { Auth } from '../../../services/Auth';
+
+// Example items used as fallback when API fails
+const STANDARD_ITEMS_MOCK = {
+  "standardId": 1,
+  "model": [
+    {"id":23,"idModel":6,"minQty":0,"maxQty":5,"createdAt":"2025-08-25T21:56:41Z","modelName":"DCX700"},
+    {"id":25,"idModel":4,"minQty":0,"maxQty":5,"createdAt":"2025-08-25T21:56:41Z","modelName":"EG2482"},
+    {"id":21,"idModel":1,"minQty":10,"maxQty":25,"createdAt":"2025-08-25T21:56:41Z","modelName":"FAST5670"},
+    {"id":22,"idModel":5,"minQty":0,"maxQty":5,"createdAt":"2025-08-25T21:56:41Z","modelName":"FAST5670"},
+    {"id":24,"idModel":7,"minQty":0,"maxQty":5,"createdAt":"2025-08-25T21:56:41Z","modelName":"UIW4054MIL"}
+  ],
+  "material": [
+    {"id":9,"idMaterial":2,"minQty":1,"maxQty":10,"createdAt":"2025-08-25T21:56:41Z","materialName":null}
+  ],
+  "group": [
+    {
+      "id":10,"idGroup":1,"minQty":2,"maxQty":4,"createdAt":"2025-08-26T20:33:28Z",
+      "groupName":"HD","linkedModelsCount":2,
+      "linkedModels":[
+        {"idModel":2,"modelName":"WIFI DOCSIS 3.0"},
+        {"idModel":3,"modelName":"DCX700"}
+      ]
+    }
+  ],
+  "counts":{"model":5,"material":1,"group":1}
+};
+
+const CargaCertificadaPage = () => {
+  const [selectedWarehouse, setSelectedWarehouse] = useState(null);
+  const [items, setItems] = useState({ models: [], groups: [], materials: [] });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      if (!selectedWarehouse) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(
+          `${Backend.equipments.standardLoad.url}/${selectedWarehouse.idStandar}/items`,
+          Auth.authorize()
+        );
+        if (!res.ok) throw new Error('Error');
+        const data = await res.json();
+        setItems({
+          models: data.model || [],
+          groups: data.group || [],
+          materials: data.material || []
+        });
+      } catch (e) {
+        console.error(e);
+        setError('Fallo obteniendo ítems, usando datos locales');
+        setItems({
+          models: STANDARD_ITEMS_MOCK.model,
+          groups: STANDARD_ITEMS_MOCK.group,
+          materials: STANDARD_ITEMS_MOCK.material
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchItems();
+  }, [selectedWarehouse]);
+
+  const handleExport = materialsRead => {
+    if (!selectedWarehouse) return;
+    const payload = {
+      warehouseId: selectedWarehouse.id,
+      idStandar: selectedWarehouse.idStandar,
+      materialsRead
+    };
+    console.log(payload);
+  };
+
+  return (
+    <Box p={2}>
+      <Typography variant="h4" gutterBottom>Carga Certificada</Typography>
+      <WarehouseSearch onSelect={setSelectedWarehouse} selectedWarehouse={selectedWarehouse} />
+      {selectedWarehouse && (
+        <Box mt={2} mb={2}>
+          <Typography variant="h6">Detalle del carrito</Typography>
+          <Typography>Nombre: {selectedWarehouse.name}</Typography>
+          <Typography>Reseller: {selectedWarehouse.resellerCode}</Typography>
+          <Box display="flex" alignItems="center" style={{ gap: 8 }}>
+            <Typography>Tipo:</Typography>
+            <Chip label={selectedWarehouse.type} size="small" />
+          </Box>
+          <Typography>idStandar: {selectedWarehouse.idStandar}</Typography>
+        </Box>
+      )}
+      {loading && <LinearProgress />}
+      {!loading && error && (
+        <Box
+          mb={2}
+          p={2}
+          borderRadius={4}
+          bgcolor="#fdecea"
+          color="#b71c1c"
+        >
+          {error}
+        </Box>
+      )}
+      {!loading && !error && selectedWarehouse && (
+        <StandardItemsTable
+          models={items.models}
+          groups={items.groups}
+          materials={items.materials}
+          onExport={handleExport}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default CargaCertificadaPage;

--- a/src/containers/equipments/CargaCertificada/GroupRow.js
+++ b/src/containers/equipments/CargaCertificada/GroupRow.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { TableRow, TableCell, List, ListItem, ListItemText } from '@material-ui/core';
+
+const GroupRow = ({ group }) => (
+  <TableRow>
+    <TableCell colSpan={5} style={{ backgroundColor: '#fafafa' }}>
+      <List dense>
+        {group.linkedModels && group.linkedModels.map(m => (
+          <ListItem key={m.idModel} style={{ paddingTop: 0, paddingBottom: 0 }}>
+            <ListItemText primary={m.modelName} />
+          </ListItem>
+        ))}
+      </List>
+    </TableCell>
+  </TableRow>
+);
+
+export default GroupRow;

--- a/src/containers/equipments/CargaCertificada/StandardItemsTable.js
+++ b/src/containers/equipments/CargaCertificada/StandardItemsTable.js
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  TextField
+} from '@material-ui/core';
+import GroupRow from './GroupRow';
+
+// validate float with max decimals
+export const isValidFloat = (value, maxDecimals = 2) => {
+  if (value === '') return true;
+  const regex = new RegExp(`^\\d*(\\.\\d{0,${maxDecimals}})?$`);
+  return regex.test(value);
+};
+
+const StandardItemsTable = ({ models = [], groups = [], materials = [], onExport }) => {
+  const [reads, setReads] = useState({});
+  const [expanded, setExpanded] = useState({});
+
+  const handleExpand = id => {
+    setExpanded(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleReadChange = (item, value) => {
+    setReads(prev => ({ ...prev, [item.id]: { id: item.id, idMaterial: item.idMaterial, readQty: value } }));
+  };
+
+  const getError = item => {
+    const entry = reads[item.id];
+    const value = entry ? entry.readQty : '';
+    if (value === '') return '';
+    if (!isValidFloat(value)) return 'Número inválido';
+    if (parseFloat(value) > item.maxQty) return 'Supera máximo';
+    return '';
+  };
+
+  const exportData = () => {
+    const materialsRead = Object.values(reads)
+      .filter(r => r.readQty !== '' && isValidFloat(r.readQty))
+      .map(r => ({ id: r.id, idMaterial: r.idMaterial, readQty: parseFloat(r.readQty) }));
+    onExport && onExport(materialsRead);
+  };
+
+  const hasRows = models.length + groups.length + materials.length > 0;
+
+  return (
+    <Box>
+      <TableContainer component={Paper} style={{ maxHeight: 400, marginBottom: 16 }}>
+        <Table stickyHeader size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Nombre</TableCell>
+              <TableCell>Disponible (Mínimo)</TableCell>
+              <TableCell>Por Cargar (Máximo)</TableCell>
+              <TableCell>Leído/Cargado</TableCell>
+              <TableCell>Acción</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {models.map(m => (
+              <TableRow key={`model-${m.id}`}>
+                <TableCell>{m.modelName}</TableCell>
+                <TableCell>{m.minQty}</TableCell>
+                <TableCell>{m.maxQty}</TableCell>
+                <TableCell />
+                <TableCell />
+              </TableRow>
+            ))}
+            {groups.map(g => (
+              <React.Fragment key={`group-${g.id}`}>
+                <TableRow>
+                  <TableCell>{g.groupName}</TableCell>
+                  <TableCell>{g.minQty}</TableCell>
+                  <TableCell>{g.maxQty}</TableCell>
+                  <TableCell />
+                  <TableCell>
+                    <Button size="small" onClick={() => handleExpand(g.id)}>Ver</Button>
+                  </TableCell>
+                </TableRow>
+                {expanded[g.id] && <GroupRow group={g} />}
+              </React.Fragment>
+            ))}
+            {materials.map(mat => {
+              const value = reads[mat.id]?.readQty || '';
+              const err = getError(mat);
+              return (
+                <TableRow key={`material-${mat.id}`}>
+                  <TableCell>{mat.materialName || 'Material sin nombre'}</TableCell>
+                  <TableCell>{mat.minQty}</TableCell>
+                  <TableCell>{mat.maxQty}</TableCell>
+                  <TableCell>
+                    <TextField
+                      type="number"
+                      value={value}
+                      onChange={e => handleReadChange(mat, e.target.value)}
+                      size="small"
+                      inputProps={{ step: 0.1, min: 0 }}
+                      error={Boolean(err)}
+                      helperText={err}
+                    />
+                  </TableCell>
+                  <TableCell />
+                </TableRow>
+              );
+            })}
+            {!hasRows && (
+              <TableRow>
+                <TableCell colSpan={5} align="center">Sin resultados</TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+      {hasRows && (
+        <Box textAlign="right">
+          <Button variant="contained" onClick={exportData}>Exportar cambios</Button>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default StandardItemsTable;

--- a/src/containers/equipments/CargaCertificada/WarehouseSearch.js
+++ b/src/containers/equipments/CargaCertificada/WarehouseSearch.js
@@ -1,0 +1,139 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  Box,
+  TextField,
+  Select,
+  MenuItem,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  LinearProgress
+} from '@material-ui/core';
+import { Backend } from '../../../data';
+import { Auth } from '../../../services/Auth';
+
+// Example warehouses used as fallback when API fails
+const WAREHOUSE_MOCK = {
+  content: [
+    {"id":1,"name":"CAPA80","resellerCode":"CAPA","type":"CAR","idStandar":1,"status":"enable"},
+    {"id":2,"name":"Bodega Interior","resellerCode":"TIGO","type":"STORAGE","idStandar":2,"status":"enable"},
+    {"id":3,"name":"Bodega Woden","resellerCode":"Woden","type":"STORAGE","idStandar":3,"status":"enable"},
+    {"id":4,"name":"CAPA81","resellerCode":"capa1","type":"CAR","idStandar":4,"status":"enable"}
+  ]
+};
+
+const WarehouseSearch = ({ onSelect, selectedWarehouse }) => {
+  const [warehouses, setWarehouses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [type, setType] = useState('CAR');
+
+  // fetch warehouses once
+  useEffect(() => {
+    const fetchWarehouses = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(Backend.equipments.warehouses.url, Auth.authorize());
+        if (!res.ok) throw new Error('Error al cargar');
+        const data = await res.json();
+        setWarehouses(data.content || []);
+      } catch (e) {
+        console.error(e);
+        setError('Fallo obteniendo carritos, usando datos locales');
+        setWarehouses(WAREHOUSE_MOCK.content);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchWarehouses();
+  }, []);
+
+  // debounce search query
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(handler);
+  }, [query]);
+
+  // clear selection when type changes and current selection does not match
+  useEffect(() => {
+    if (selectedWarehouse && selectedWarehouse.type !== type) {
+      onSelect && onSelect(null);
+    }
+  }, [type]);
+
+  const filtered = useMemo(() =>
+    warehouses
+      .filter(w => w.type === type)
+      .filter(w => w.name.toLowerCase().startsWith(debouncedQuery.toLowerCase()))
+  , [warehouses, type, debouncedQuery]);
+
+  return (
+    <Box>
+      <Box display="flex" mb={2} style={{ gap: 16 }}>
+        <TextField
+          label="Buscar carrito"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          size="small"
+        />
+        <Select value={type} onChange={e => setType(e.target.value)} size="small">
+          <MenuItem value="CAR">CAR</MenuItem>
+          <MenuItem value="STORAGE">STORAGE</MenuItem>
+        </Select>
+      </Box>
+      {loading && <LinearProgress />}
+      {!loading && error && (
+        <Box
+          mb={2}
+          p={2}
+          borderRadius={4}
+          bgcolor="#fdecea"
+          color="#b71c1c"
+        >
+          {error}
+        </Box>
+      )}
+      {!loading && (
+        <TableContainer component={Paper} style={{ maxHeight: 240 }}>
+          <Table stickyHeader size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Nombre</TableCell>
+                <TableCell>Reseller</TableCell>
+                <TableCell>Tipo</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {filtered.map(w => (
+                <TableRow
+                  hover
+                  key={w.id}
+                  onClick={() => onSelect && onSelect(w)}
+                  selected={selectedWarehouse && selectedWarehouse.id === w.id}
+                  style={{ cursor: 'pointer' }}
+                >
+                  <TableCell>{w.name}</TableCell>
+                  <TableCell>{w.resellerCode}</TableCell>
+                  <TableCell>{w.type}</TableCell>
+                </TableRow>
+              ))}
+              {filtered.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={3} align="center">Sin resultados</TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+};
+
+export default WarehouseSearch;

--- a/src/data.js
+++ b/src/data.js
@@ -83,6 +83,14 @@ export const System = {
       category: 'equipments',
     },
     {
+      id: 'certifiedLoad',
+      text: t('menu.certifiedLoad'),
+      icon: <Storefront />,
+      link: ROUTES.certifiedLoad.path,
+      requiredPermissions: [resourcesScopes.ancillaryEquipments.read],
+      category: 'equipments',
+    },
+    {
       id: 'equipmentsAdmin',
       text: t('menu.admin'),
       icon: <Settings />,
@@ -350,6 +358,10 @@ export const Backend = {
     },
     standardLoads: {
       url: Config.tecrepApiEquipmentsUrl + '/api/v2/private/auth/standard-loads',
+    },
+    // Single standard load used to fetch its items
+    standardLoad: {
+      url: Config.tecrepApiEquipmentsUrl + '/api/v1/private/auth/standard-load',
     },
     jobConfiguration: {
       url: `${Config.tecrepApiEquipmentsUrl}/api/v1/private/auth/job/configuration`

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -485,6 +485,7 @@
   "menu.equipments": "Equipments",
   "menu.resources": "Resources",
   "menu.ancillaryEquipments": "Ancillary equipments",
+  "menu.certifiedLoad": "Certified load",
   "menu.address": "Address",
   "menu.building": "Building",
   "menu.postalAdresses": "Postal Adresses",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -495,6 +495,7 @@
   "menu.equipments": "Equipements",
   "menu.resources": "Ressources",
   "menu.ancillaryEquipments": "Equipements auxiliaires",
+  "menu.certifiedLoad": "Charge certifiée",
   "menu.address": "Adresses",
   "menu.building": "Bâtiment",
   "menu.postalAdresses": "Adresses postales",


### PR DESCRIPTION
## Summary
- migrate Carga Certificada components to Material-UI v4
- replace `sx` props with Box/system props or inline styles
- fetch warehouses and standard-load items using shared Backend endpoints with auth headers
- drop `@material-ui/lab` by rendering inline error boxes
- define `standardLoad` backend endpoint and reference it when loading items

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b06cc39b608323b9bd012a7554b500