### PR TITLE
feat: add certified load start button

### DIFF
--- a/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
+++ b/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Box, Typography, Chip, LinearProgress } from '@material-ui/core';
 import WarehouseSearch from './WarehouseSearch';
 import StandardItemsTable from './StandardItemsTable';
@@ -37,50 +37,67 @@ const CargaCertificadaPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    const fetchItems = async () => {
-      if (!selectedWarehouse) return;
-   // Normaliza: trata undefined, null, "null", "" y NaN como SIN estándar
-      const raw = selectedWarehouse.idStandar;
-      const normalized =
-        raw === undefined || raw === null || raw === '' || raw === 'null'
-          ? null
-          : raw;
+  const fetchItems = async () => {
+    if (!selectedWarehouse) return;
+    // Normaliza: trata undefined, null, "null", "" y NaN como SIN estándar
+    const raw = selectedWarehouse.idStandar;
+    const normalized =
+      raw === undefined || raw === null || raw === '' || raw === 'null'
+        ? null
+        : raw;
 
-      if (normalized === null) {
-        setItems({ models: [], groups: [], materials: [] });
-        setError('Este carrito no tiene estándar asociado.');
-        setLoading(false);
-        return;
-      }
-      setLoading(true);
-      setError(null);
-       try {
-        const res = await fetch(
-          `${Backend.equipments.standardLoad.url}/${selectedWarehouse.idStandar}/items`,
-          Auth.authorize()
-        );
-        if (!res.ok) throw new Error('Error');
-        const data = await res.json();
-        setItems({
-          models: data.model || [],
-          groups: data.group || [],
-          materials: data.material || []
-        });
-      } catch (e) {
-        console.error(e);
-        setError('Fallo obteniendo ítems, usando datos locales');
-        setItems({
-          models: STANDARD_ITEMS_MOCK.model,
-          groups: STANDARD_ITEMS_MOCK.group,
-          materials: STANDARD_ITEMS_MOCK.material
-        });
-       } finally {
-        setLoading(false);
-      }
-    };
-    fetchItems();
-  }, [selectedWarehouse]);
+    if (normalized === null) {
+      setItems({ models: [], groups: [], materials: [] });
+      setError('Este carrito no tiene estándar asociado.');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `${Backend.equipments.standardLoad.url}/${selectedWarehouse.idStandar}/items`,
+        Auth.authorize()
+      );
+      if (!res.ok) throw new Error('Error');
+      const data = await res.json();
+      setItems({
+        models: data.model || [],
+        groups: data.group || [],
+        materials: data.material || [],
+      });
+    } catch (e) {
+      console.error(e);
+      setError('Fallo obteniendo ítems, usando datos locales');
+      setItems({
+        models: STANDARD_ITEMS_MOCK.model,
+        groups: STANDARD_ITEMS_MOCK.group,
+        materials: STANDARD_ITEMS_MOCK.material,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const showStartButton = selectedWarehouse?.idStandar === 2;
+
+  const handleStart = async () => {
+    if (!selectedWarehouse) return;
+    const auth = Auth.authorize();
+    try {
+      await fetch(Backend.equipments.certifiedLoad.url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(auth.headers || {}) },
+        body: JSON.stringify({
+          warehouse_id: selectedStorageId,
+          car_id: selectedWarehouse.id,
+        }),
+      });
+    } catch (e) {
+      console.error(e);
+    }
+    await fetchItems();
+  };
 
   const handleExport = (materialsRead) => {
     if (!selectedWarehouse) return;
@@ -100,7 +117,10 @@ const CargaCertificadaPage = () => {
       <WarehouseSearch
         onSelect={setSelectedWarehouse}
         selectedWarehouse={selectedWarehouse}
+        selectedStorageId={selectedStorageId}
         onStorageSelect={(id /*, storageObj */) => setSelectedStorageId(id)}
+        showStartButton={showStartButton}
+        onStart={handleStart}
       />
 
       {selectedWarehouse && (

--- a/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
+++ b/src/containers/equipments/CargaCertificada/CargaCertificadaPage.js
@@ -36,6 +36,7 @@ const CargaCertificadaPage = () => {
   const [items, setItems] = useState({ models: [], groups: [], materials: [] });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [itemsLoaded, setItemsLoaded] = useState(false);
 
   const fetchItems = async () => {
     if (!selectedWarehouse) return;
@@ -50,6 +51,7 @@ const CargaCertificadaPage = () => {
       setItems({ models: [], groups: [], materials: [] });
       setError('Este carrito no tiene estándar asociado.');
       setLoading(false);
+      setItemsLoaded(true);
       return;
     }
     setLoading(true);
@@ -76,6 +78,7 @@ const CargaCertificadaPage = () => {
       });
     } finally {
       setLoading(false);
+      setItemsLoaded(true);
     }
   };
 
@@ -110,12 +113,19 @@ const CargaCertificadaPage = () => {
     console.log(payload);
   };
 
+  const handleSelectWarehouse = (wh) => {
+    setSelectedWarehouse(wh);
+    setItems({ models: [], groups: [], materials: [] });
+    setError(null);
+    setItemsLoaded(false);
+  };
+
   return (
     <Box p={2}>
       <Typography variant="h4" gutterBottom>Carga Certificada</Typography>
 
       <WarehouseSearch
-        onSelect={setSelectedWarehouse}
+        onSelect={handleSelectWarehouse}
         selectedWarehouse={selectedWarehouse}
         selectedStorageId={selectedStorageId}
         onStorageSelect={(id /*, storageObj */) => setSelectedStorageId(id)}
@@ -123,35 +133,34 @@ const CargaCertificadaPage = () => {
         onStart={handleStart}
       />
 
-      {selectedWarehouse && (
-        <Box mt={2} mb={2}>
-          <Typography variant="h6">Detalle del carrito</Typography>
-          <Typography>Nombre: {selectedWarehouse.name}</Typography>
-          <Typography>SAP: {selectedWarehouse.resellerCode}</Typography>
-          <Box display="flex" alignItems="center" style={{ gap: 8 }}>
-            <Typography>Tipo:</Typography>
-            <Chip label={selectedWarehouse.type} size="small" />
-          </Box>
-          <Typography>idStandar: {selectedWarehouse.idStandar}</Typography>
-          {selectedStorageId != null && (
-            <Typography>Bodega seleccionada (id): {selectedStorageId}</Typography>
-          )}
-        </Box>
-      )}
-
       {loading && <LinearProgress />}
-      {!loading && error && (
+      {itemsLoaded && error && !loading && (
         <Box mb={2} p={2} borderRadius={4} bgcolor="#fdecea" color="#b71c1c">
           {error}
         </Box>
       )}
-      {!loading && !error && selectedWarehouse && (
-        <StandardItemsTable
-          models={items.models}
-          groups={items.groups}
-          materials={items.materials}
-          onExport={handleExport}
-        />
+      {itemsLoaded && !loading && !error && selectedWarehouse && (
+        <>
+          <Box mt={2} mb={2}>
+            <Typography variant="h6">Detalle del carrito</Typography>
+            <Typography>Nombre: {selectedWarehouse.name}</Typography>
+            <Typography>SAP: {selectedWarehouse.resellerCode}</Typography>
+            <Box display="flex" alignItems="center" style={{ gap: 8 }}>
+              <Typography>Tipo:</Typography>
+              <Chip label={selectedWarehouse.type} size="small" />
+            </Box>
+            <Typography>idStandar: {selectedWarehouse.idStandar}</Typography>
+            {selectedStorageId != null && (
+              <Typography>Bodega seleccionada (id): {selectedStorageId}</Typography>
+            )}
+          </Box>
+          <StandardItemsTable
+            models={items.models}
+            groups={items.groups}
+            materials={items.materials}
+            onExport={handleExport}
+          />
+        </>
       )}
     </Box>
   );

--- a/src/containers/equipments/CargaCertificada/WarehouseSearch.js
+++ b/src/containers/equipments/CargaCertificada/WarehouseSearch.js
@@ -1,17 +1,10 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   TextField,
-  Select,
   MenuItem,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  LinearProgress
+  LinearProgress,
+  Button,
 } from '@material-ui/core';
 import { Backend } from '../../../data';
 import { Auth } from '../../../services/Auth';
@@ -19,22 +12,25 @@ import { Auth } from '../../../services/Auth';
 // Example warehouses used as fallback when API fails
 const WAREHOUSE_MOCK = {
   content: [
-    {"id":1,"name":"CAPA80","resellerCode":"CAPA","type":"CAR","idStandar":1,"status":"enable"},
-    {"id":2,"name":"Bodega Interior","resellerCode":"TIGO","type":"STORAGE","idStandar":2,"status":"enable"},
-    {"id":3,"name":"Bodega Woden","resellerCode":"Woden","type":"STORAGE","idStandar":3,"status":"enable"},
-    {"id":4,"name":"CAPA81","resellerCode":"capa1","type":"CAR","idStandar":4,"status":"enable"}
-  ]
+    { id: 1, name: 'CAPA80', resellerCode: 'CAPA', type: 'CAR', idStandar: 1, status: 'enable' },
+    { id: 2, name: 'Bodega Interior', resellerCode: 'TIGO', type: 'STORAGE', idStandar: 2, status: 'enable' },
+    { id: 3, name: 'Bodega Woden', resellerCode: 'Woden', type: 'STORAGE', idStandar: 3, status: 'enable' },
+    { id: 4, name: 'CAPA81', resellerCode: 'capa1', type: 'CAR', idStandar: 4, status: 'enable' },
+  ],
 };
 
-const WarehouseSearch = ({ onSelect, selectedWarehouse }) => {
+const WarehouseSearch = ({
+  selectedWarehouse,
+  onSelect,
+  selectedStorageId,
+  onStorageSelect,
+  showStartButton,
+  onStart,
+}) => {
   const [warehouses, setWarehouses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [query, setQuery] = useState('');
-  const [debouncedQuery, setDebouncedQuery] = useState('');
-  const [type, setType] = useState('CAR');
 
-  // fetch warehouses once
   useEffect(() => {
     const fetchWarehouses = async () => {
       setLoading(true);
@@ -54,83 +50,50 @@ const WarehouseSearch = ({ onSelect, selectedWarehouse }) => {
     fetchWarehouses();
   }, []);
 
-  // debounce search query
-  useEffect(() => {
-    const handler = setTimeout(() => setDebouncedQuery(query), 300);
-    return () => clearTimeout(handler);
-  }, [query]);
-
-  // clear selection when type changes and current selection does not match
-  useEffect(() => {
-    if (selectedWarehouse && selectedWarehouse.type !== type) {
-      onSelect && onSelect(null);
-    }
-  }, [type]);
-
-  const filtered = useMemo(() =>
-    warehouses
-      .filter(w => w.type === type)
-      .filter(w => w.name.toLowerCase().startsWith(debouncedQuery.toLowerCase()))
-  , [warehouses, type, debouncedQuery]);
+  const storages = warehouses.filter(w => w.type === 'STORAGE');
+  const cars = warehouses.filter(w => w.type === 'CAR');
 
   return (
-    <Box>
-      <Box display="flex" mb={2} style={{ gap: 16 }}>
-        <TextField
-          label="Buscar carrito"
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          size="small"
-        />
-        <Select value={type} onChange={e => setType(e.target.value)} size="small">
-          <MenuItem value="CAR">CAR</MenuItem>
-          <MenuItem value="STORAGE">STORAGE</MenuItem>
-        </Select>
-      </Box>
-      {loading && <LinearProgress />}
-      {!loading && error && (
-        <Box
-          mb={2}
-          p={2}
-          borderRadius={4}
-          bgcolor="#fdecea"
-          color="#b71c1c"
-        >
-          {error}
-        </Box>
+    <Box mb={2} display="flex" alignItems="center" style={{ gap: 16 }}>
+      <TextField
+        select
+        label="Bodega"
+        value={selectedStorageId ?? ''}
+        onChange={e => onStorageSelect && onStorageSelect(Number(e.target.value))}
+        size="small"
+        variant="outlined"
+      >
+        {storages.map(s => (
+          <MenuItem key={s.id} value={s.id}>
+            {s.name}
+          </MenuItem>
+        ))}
+      </TextField>
+      <TextField
+        select
+        label="Carrito"
+        value={selectedWarehouse ? selectedWarehouse.id : ''}
+        onChange={e => {
+          const w = cars.find(c => c.id === Number(e.target.value));
+          onSelect && onSelect(w || null);
+        }}
+        size="small"
+        variant="outlined"
+      >
+        {cars.map(c => (
+          <MenuItem key={c.id} value={c.id}>
+            {c.name}
+          </MenuItem>
+        ))}
+      </TextField>
+      {showStartButton && (
+        <Button variant="contained" color="primary" onClick={onStart}>
+          Iniciar
+        </Button>
       )}
-      {!loading && (
-        <TableContainer component={Paper} style={{ maxHeight: 240 }}>
-          <Table stickyHeader size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Nombre</TableCell>
-                <TableCell>Reseller</TableCell>
-                <TableCell>Tipo</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {filtered.map(w => (
-                <TableRow
-                  hover
-                  key={w.id}
-                  onClick={() => onSelect && onSelect(w)}
-                  selected={selectedWarehouse && selectedWarehouse.id === w.id}
-                  style={{ cursor: 'pointer' }}
-                >
-                  <TableCell>{w.name}</TableCell>
-                  <TableCell>{w.resellerCode}</TableCell>
-                  <TableCell>{w.type}</TableCell>
-                </TableRow>
-              ))}
-              {filtered.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={3} align="center">Sin resultados</TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+      {loading && <LinearProgress style={{ flex: 1 }} />}
+      {!loading && error && (
+        <Box color="#b71c1c">{error}</Box>
       )}
     </Box>
   );

--- a/src/data.js
+++ b/src/data.js
@@ -363,6 +363,9 @@ export const Backend = {
     standardLoad: {
       url: Config.tecrepApiEquipmentsUrl + '/api/v1/private/auth/standard-load',
     },
+    certifiedLoad: {
+      url: Config.tecrepApiEquipmentsUrl + '/api/v2/private/auth/certifiedload',
+    },
     jobConfiguration: {
       url: `${Config.tecrepApiEquipmentsUrl}/api/v1/private/auth/job/configuration`
     },


### PR DESCRIPTION
## Summary
- add certified load API endpoint constant
- allow selecting warehouse/cart and start certified load manually
- fetch standard items only after starting certified load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1e5b994b083238c95087dcd4a73e3